### PR TITLE
SaveDataクラスとPlayerDataクラスを作成しました

### DIFF
--- a/Assets/Scripts/DataSave.cs
+++ b/Assets/Scripts/DataSave.cs
@@ -1,0 +1,51 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using System.IO;
+
+[System.Serializable]
+public class PlayerData
+{
+    public int m_winValue;
+    public int m_loseValue;
+
+    public PlayerData(){ }
+    public PlayerData(int winValue,int loseValue)
+    {
+        m_winValue = winValue;
+        m_loseValue = loseValue;
+    }
+    public static PlayerData operator +(PlayerData left, PlayerData right)
+        => new PlayerData(left.m_winValue + right.m_winValue, left.m_loseValue + right.m_loseValue); 
+}
+
+public class DataSave : MonoBehaviour
+{
+
+    public static string filePath = Application.persistentDataPath + "/" + ".player.json";
+    public static void PlayerDataSave(PlayerData playerData)
+    {
+        PlayerData saveData = PlayerDataLode();
+        saveData = saveData + playerData;
+
+        string json = JsonUtility.ToJson(saveData);
+
+        StreamWriter streamWriter = new StreamWriter(filePath);
+        streamWriter.Write(json);
+        streamWriter.Flush();
+        streamWriter.Close();
+    }
+
+    public static PlayerData PlayerDataLode()
+    {
+        PlayerData data = new PlayerData(0, 0);
+        if (File.Exists(filePath))
+        {
+            StreamReader streamReader = new StreamReader(filePath);
+            string lodeData = streamReader.ReadToEnd();
+            data = JsonUtility.FromJson<PlayerData>(lodeData);
+            streamReader.Close();
+        }
+        return data;
+    }
+}

--- a/Assets/Scripts/DataSave.cs.meta
+++ b/Assets/Scripts/DataSave.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 75bf163266ad1834d9eac735fcecbfa5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
データを保存するためのクラスであるSaveDataクラスとプレイヤーのデータを保持するクラスPlayerDataクラスを作成しました。
今回はPlayerDataクラスをjsonファイルに変換して保存しています。
データを保存する場合はPlayerDataSaveメソッドを使用してください
データを読み込む場合はPlayerDataLoadメソッドを使用してください
jsonファイルの保存先はunityのpersistentDataPath以下にplayer.jsonという名前で保存しています
