### PR TITLE
ゲームが終わってもカメラが破棄されないようにしました

### DIFF
--- a/Assets/Scripts/HPManager.cs
+++ b/Assets/Scripts/HPManager.cs
@@ -61,7 +61,12 @@ public class HPManager : MonoBehaviour
     void Destroy(int playerId)
     {
         RaiseResultEvent(EventCode.gameSet, playerId);
-        NetworkGameManager.Destroy(gameObject);
+        GameObject[] gameObjects = GameObject.FindGameObjectsWithTag("Player");
+        foreach (var item in gameObjects)
+        {
+            NetworkPlayerController controller = item.GetComponent<NetworkPlayerController>();
+            controller.enabled = false;
+        }
         Debug.LogFormat("" + m_photonView.Owner.ActorNumber, gameObject.name);
     }
 


### PR DESCRIPTION
ゲームが終わってもカメラが破棄されないようにして勝敗表示が各クライアントから見れるようにしました
方法としてはゲームオブジェクトを破棄するのではなくプレイヤーゲームオブジェクトのプレイヤーコントローラーを無効にしています